### PR TITLE
rename app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Use Query Tool
+# Land Use Lookup
 
-The [Use Query Tool](https://nycplanning.github.io/edr-use-query-tool/) is intended to make use allowance rules clear and accessible to business and property owners, city staff, and the public in the wake of changes adopted through [City of Yes](https://www.nyc.gov/content/planning/pages/our-work?active=citywide).
+The [Land Use Lookup](https://nycplanning.github.io/land-use-lookup/) tool is intended to make use allowance rules clear and accessible to business and property owners, city staff, and the public in the wake of changes adopted through [City of Yes](https://www.nyc.gov/content/planning/pages/our-work?active=citywide).
 
 This simple web tool allows a user to instantly check whether any particular commercial, residential, or other use is allowed in any zoning district per the [Zoning Resolution](https://zr.planning.nyc.gov/), without having to navigate the text directly. Use allowances can be queried by their official Zoning-defined use names, associated/underlying NAICS indices, or by selecting a zoning district and seeing a full list of what’s allowed there.
 

--- a/query_app.py
+++ b/query_app.py
@@ -11,7 +11,11 @@
 import marimo
 
 __generated_with = "0.19.4"
-app = marimo.App(width="medium", css_file="public/custom.css")
+app = marimo.App(
+    width="medium",
+    app_title="Land Use Lookup",
+    css_file="public/custom.css",
+)
 
 with app.setup:
     import marimo as mo


### PR DESCRIPTION
app title now shows as "Land Use Lookup" in browser tabs instead of the default of the file name

<img width="553" height="36" alt="Screenshot 2026-03-30 at 10 38 06 PM" src="https://github.com/user-attachments/assets/fe9a12e3-d797-46a3-ad07-922d5e828dae" />
